### PR TITLE
Added missing shebang for pwsh

### DIFF
--- a/azure-export.ps1
+++ b/azure-export.ps1
@@ -1,3 +1,4 @@
+#!/usr/bin/env pwsh
 <#
 Copyright 2021 Google LLC
 Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
The default runtime for Azure Cloud Shell is bash and the `azure-export.ps1` script fails to execute when not running by prefixing `pwsh`. This PR will add a shebang for PowerShell so the script can be executed directly from bash as per `README.md` or from a Azure Cloud Shell that is started with a PowerShell runtime.