### PR TITLE
Skip VMs that are not in a running state

### DIFF
--- a/azure-export.ps1
+++ b/azure-export.ps1
@@ -422,6 +422,11 @@ foreach ($sub in $subList){
         $vmSizeInfo = Get-AzVMSize -VMName $vm.Name -ResourceGroupName $vm.ResourceGroupName | Where-Object{$_.Name -eq $vm.HardwareProfile.VmSize} -erroraction 'silentlycontinue'
         $vmStatusInfo = Get-AzVM -Name $vm.Name -ResourceGroupName $vm.ResourceGroupName -Status -erroraction 'silentlycontinue'
         
+        # Skip over non-running VMs
+        if ($vmStatusInfo.Statuses[1].DisplayStatus -ne 'VM running') {
+          continue
+        }
+        
         if($vmSizeInfo -and $vmStatusInfo) {
             $ipInfo = GetVmIpinfo($vm)
         


### PR DESCRIPTION
VMs that are stopped/deallocated may be have been off for long enough that the performance metrics may be null.