### PR TITLE
Fix string interpolation for subscription name in log

### DIFF
--- a/azure-export.ps1
+++ b/azure-export.ps1
@@ -387,7 +387,7 @@ $vmCount = 0
 $vmsscount = 0
 # Loop through all subscriptions user has access to
 foreach ($sub in $subList){
-	LogMessage("Processing Subscription $($sub.Name)")
+	LogMessage("Processing Subscription '$($sub.Name)'")
 
 	Select-AzSubscription -SubscriptionId $sub.Id
 	Set-AzContext -SubscriptionId $sub.Id

--- a/azure-export.ps1
+++ b/azure-export.ps1
@@ -387,7 +387,7 @@ $vmCount = 0
 $vmsscount = 0
 # Loop through all subscriptions user has access to
 foreach ($sub in $subList){
-	LogMessage("Processing Subscription $sub.Name")
+	LogMessage("Processing Subscription $($sub.Name)")
 
 	Select-AzSubscription -SubscriptionId $sub.Id
 	Set-AzContext -SubscriptionId $sub.Id


### PR DESCRIPTION
Interpolation for the subscription name does not work as intended and produces log entries like this:

```
2/1/2023 1:14:28 PM - Processing Subscription 3ad28742-d77c-4e2e-b4c6-b4b1adf8e3a9.Name
```

This PR fixes interpolation to produce log entries like:

```
2/1/2023 1:28:51 PM - Processing Subscription 'My subscription'
```